### PR TITLE
feat: support TS4 import declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ts-rename-import-plugin
 
-Rename import pathes in typescript compile result.
+Rename import paths in typescript compile result.
 
 ## UseCases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,38 @@
 {
   "name": "ts-rename-import-plugin",
   "version": "1.1.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^13.9.0",
+        "typescript": "^3.8.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "13.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
+      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/node": {
       "version": "13.9.3",
@@ -12,8 +42,9 @@
     },
     "typescript": {
       "version": "3.8.3",
-      "resolved": "https://registry.npm.taobao.org/typescript/download/typescript-3.8.3.tgz",
-      "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE="
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "url": "https://github.com/banyudu/ts-rename-import-plugin/issues"
   },
   "homepage": "https://github.com/banyudu/ts-rename-import-plugin#readme",
-  "dependencies": {
-    "typescript": "^3.8.3"
+  "peerDependencies": {
+    "typescript": ">=3 <=4"
   },
   "devDependencies": {
-    "@types/node": "^13.9.0"
+    "@types/node": "^13.9.0",
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
fixes #4 

This PR adds `typescript` as a peer dependency, so that AST node utils use the locally installed TS version and numeric values of `SyntaxKind` enums reoslve as needed.